### PR TITLE
Account for verb conjugation ("likes this" vs "like this")

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -224,7 +224,11 @@ function blockByKeywords(res) {
   if (res['hide-promoted']) keywords.push('Promoted')
   if (res['hide-shared']) keywords.push('feed-shared-mini-update-v2')
   if (res['hide-followed']) keywords.push('following')
-  if (res['hide-liked']) keywords.push('likes this')
+  if (res['hide-liked'])
+    keywords.push(
+      'likes this',
+      'like this'
+    )
   if (res['hide-other-reactions'])
     keywords.push(
       'loves this',


### PR DESCRIPTION
Fixes issue #27 

P.S. I'm not sure if LinkedIn also conjugates these other verbs: "loves", "finds", "celebrates", "is". Hence, I've left the array of keywords pushed for `res['hide-other-reactions']` as it was before.