### PR TITLE
Add Hide LinkedIn News

### DIFF
--- a/background.js
+++ b/background.js
@@ -21,6 +21,7 @@ chrome.storage.local.get(null, function (res) {
       "hide-links": false,
       "hide-polls": true,
       "hide-premium": true,
+      "hide-news": false,
       "hide-promoted": true,
       "hide-shared": false,
       "hide-videos": false,

--- a/content/content.js
+++ b/content/content.js
@@ -89,6 +89,13 @@ async function doIt(res) {
     showOther('premium-upsell-link')
     showOther('gp-promo-embedded-card-three__card')
   }
+
+  // Hide news
+  if (res['main-toggle'] && res['hide-news']) {
+    hideOther('news-module')
+  } else {
+    showOther('news-module')
+  }
 }
 
 function getStorageAndDoIt() {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -27,8 +27,8 @@
       <div class="container onoffswitch mb-5">
         <input type="checkbox" class="onoffswitch-checkbox" id="main-toggle" tabindex="0" checked>
         <label class="onoffswitch-label" for="main-toggle">
-            <span class="onoffswitch-inner"></span>
-            <span class="onoffswitch-switch"></span>
+          <span class="onoffswitch-inner"></span>
+          <span class="onoffswitch-switch"></span>
         </label>
       </div>
 
@@ -44,8 +44,11 @@
 
       <div class="content has-text-centered">
         <p>
-          <strong>Link Off - LinkedIn Filter and Customizer</strong> by <a href="https://jelich.cc">Noah Jelich</a>. The source code is licensed
-          <a href="http://opensource.org/licenses/mit-license.php">MIT</a> and available on <a href="https://github.com/njelich/LinkOff">my github</a>. Add me on <a href="https://www.linkedin.com/in/njelich/">LinkedIn</a> or <a href='https://ko-fi.com/G2G547IJY'
+          <strong>Link Off - LinkedIn Filter and Customizer</strong> by <a href="https://jelich.cc">Noah Jelich</a>. The
+          source code is licensed
+          <a href="http://opensource.org/licenses/mit-license.php">MIT</a> and available on <a
+            href="https://github.com/njelich/LinkOff">my github</a>. Add me on <a
+            href="https://www.linkedin.com/in/njelich/">LinkedIn</a> or <a href='https://ko-fi.com/G2G547IJY'
             target='_blank'> Buy me a Coffee</a>
         </p>
       </div>
@@ -149,12 +152,12 @@
     <p class="is-pulled-left level-item">Hide posts older than</p>
     <div class="is-pulled-right select is-small">
       <select id="hide-by-age">
-          <option value="disabled">Disabled</option>
-          <option value="hour">an hour</option>
-          <option value="day">a day</option>
-          <option value="week">a week</option>
-          <option value="month">a month</option>
-        </select>
+        <option value="disabled">Disabled</option>
+        <option value="hour">an hour</option>
+        <option value="day">a day</option>
+        <option value="week">a week</option>
+        <option value="month">a month</option>
+      </select>
     </div>
 
   </div>
@@ -163,7 +166,9 @@
 
     <div class="block">
       <h2 class="title is-2 has-text-centered">COMING SOON</h2>
-      <p class="has-text-centered">I'm working hard on writing the new features in this category. If you'd like to help, please make a feature request on <a href="https://github.com/njelich/LinkOff">github</a> or share the extension with your colleagues.</p>
+      <p class="has-text-centered">I'm working hard on writing the new features in this category. If you'd like to help,
+        please make a feature request on <a href="https://github.com/njelich/LinkOff">github</a> or share the extension
+        with your colleagues.</p>
     </div>
 
   </div>
@@ -202,9 +207,16 @@
       <label for="hide-premium">Hide LinkedIn premium prompts</label>
     </div>
 
+    <div class="field">
+      <input id="hide-news" class="switch" type="checkbox">
+      <label for="hide-news">Hide LinkedIn News</label>
+    </div>
+
     <div class="block pt-4">
       <h2 class="title is-2 has-text-centered">WORK IN PROGRESS</h2>
-      <p class="has-text-centered">I'm working hard on writing the new features in this category. If you'd like to help, please make a feature request on <a href="https://github.com/njelich/LinkOff">github</a> or share the extension with your colleagues.</p>
+      <p class="has-text-centered">I'm working hard on writing the new features in this category. If you'd like to help,
+        please make a feature request on <a href="https://github.com/njelich/LinkOff">github</a> or share the extension
+        with your colleagues.</p>
     </div>
 
   </div>


### PR DESCRIPTION
This update adds the hide LinkedIn News feature requested in issue #26. @njelich, as this is my first time making a PR on this repo, please let me know if there's anything I need to be aware of stylistically or otherwise that you'd like me to address. I love the extension and was hoping to be able to toggle off the news module but didn't see the option. After reviewing the Issues I saw that this had been requested and just wanted to contribute to something I'm already enjoying. Thank you for your work on this! Please let me know if you need me to do anything else to get this update merged in.