### PR TITLE
feature add hide by keyword for Suggested

### DIFF
--- a/background.js
+++ b/background.js
@@ -28,6 +28,7 @@ chrome.storage.local.get(null, function (res) {
       'hide-videos': false,
       'hide-whole-feed': false,
       'hide-liked': true,
+      'hide-suggested': true,
       'hide-other-reactions': false,
       'main-toggle': true,
       'sort-by-recent': true,

--- a/content/content.js
+++ b/content/content.js
@@ -274,7 +274,7 @@ function getKeywords(res) {
   if (res['hide-by-companies'])
     keywords.push('href="https://www.linkedin.com/company/')
   if (res['hide-by-people']) keywords.push('href="https://www.linkedin.com/in/')
-
+  if (res['hide-suggested']) keywords.push('Suggested')
   console.log('LinkOff: Current keywords are', keywords)
   return keywords
 }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -152,6 +152,11 @@
     <div class="divider">Hide post by interactions</div>
 
     <div class="field">
+      <input id="hide-suggested" class="switch is-rounded" type="checkbox" />
+      <label for="hide-suggested">Hide suggestions</label>
+    </div>
+
+    <div class="field">
       <input id="hide-liked" class="switch is-rounded" type="checkbox" />
       <label for="hide-liked">Hide liked by connections</label>
     </div>


### PR DESCRIPTION
This PR resolves #55 

By default, hide by suggested will be enabled. Also, adding to the pop up menu.
<img width="405" alt="image" src="https://github.com/user-attachments/assets/0354ba2c-d99a-4e34-aa5e-22fa45b79a3e">

Example:
<img width="505" alt="image" src="https://github.com/user-attachments/assets/8d25fcf9-97df-4f07-9726-85e4b250e10a">
