### PR TITLE
fix(constants.js): updated job card selector

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 // Job selectors
-export const JOB_SELECTORS = ['.job-card-container']
+export const JOB_SELECTORS = ['.job-card-container', 'div[data-job-id]']
 
 // Feed selectors
 export const FEED_SELECTOR =

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 // Job selectors
-export const JOB_SELECTORS = ['[data-view-name="job-card"]']
+export const JOB_SELECTORS = ['.job-card-container']
 
 // Feed selectors
 export const FEED_SELECTOR =


### PR DESCRIPTION
The current selector doesn't exist anymore:

<img width="1459" height="84" alt="image" src="https://github.com/user-attachments/assets/bc4b55a4-e7e0-41c1-bc80-2b90c987e00e" />

I changed it for ".job-card-container" and it works fine:

<img width="494" height="495" alt="image" src="https://github.com/user-attachments/assets/81728c06-a454-4d3b-bde0-d41e5969a0be" />

If we wanted to make it more robust, we could add more selectors to that JOB_SELECTORS array `export const JOB_SELECTORS = ['.job-card-container', 'div[data-job-id]']` because querySelectorAll won't choose the same node twice. In case Linkedin changes it again. Let me know if you prefer this one!

I don't mind changing this in the future if it breaks again, if I get a @... It's just a one liner.