### PR TITLE
feat: add base translation files for all LinkedIn languages

### DIFF
--- a/src/locales/ar_AE.json
+++ b/src/locales/ar_AE.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/bn_IN.json
+++ b/src/locales/bn_IN.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/cs_CZ.json
+++ b/src/locales/cs_CZ.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/da_DK.json
+++ b/src/locales/da_DK.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/de_DE.json
+++ b/src/locales/de_DE.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/el_GR.json
+++ b/src/locales/el_GR.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "Profile viewers",
+  "hide-follow-recommendations": "Add to your feed",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "Retry Premium for",
+    "sidebar": "Retry Premium for"
+  },
+  "hide-games": "Today's puzzles"
+}

--- a/src/locales/es_ES.json
+++ b/src/locales/es_ES.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/fa_IR.json
+++ b/src/locales/fa_IR.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/fi_FI.json
+++ b/src/locales/fi_FI.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/fr_FR.json
+++ b/src/locales/fr_FR.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/hi_IN.json
+++ b/src/locales/hi_IN.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/hu_HU.json
+++ b/src/locales/hu_HU.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/in_ID.json
+++ b/src/locales/in_ID.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/it_IT.json
+++ b/src/locales/it_IT.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/iw_IL.json
+++ b/src/locales/iw_IL.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/ja_JP.json
+++ b/src/locales/ja_JP.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/ko_KR.json
+++ b/src/locales/ko_KR.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/mr_IN.json
+++ b/src/locales/mr_IN.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/ms_MY.json
+++ b/src/locales/ms_MY.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/nl_NL.json
+++ b/src/locales/nl_NL.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/no_NO.json
+++ b/src/locales/no_NO.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/pa_IN.json
+++ b/src/locales/pa_IN.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/pl_PL.json
+++ b/src/locales/pl_PL.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/pt_BR.json
+++ b/src/locales/pt_BR.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/ro_RO.json
+++ b/src/locales/ro_RO.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/ru_RU.json
+++ b/src/locales/ru_RU.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/sv_SE.json
+++ b/src/locales/sv_SE.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/te_IN.json
+++ b/src/locales/te_IN.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/th_TH.json
+++ b/src/locales/th_TH.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/tl_PH.json
+++ b/src/locales/tl_PH.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/tr_TR.json
+++ b/src/locales/tr_TR.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/uk_UA.json
+++ b/src/locales/uk_UA.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/vi_VN.json
+++ b/src/locales/vi_VN.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}

--- a/src/locales/zh_TW.json
+++ b/src/locales/zh_TW.json
@@ -1,0 +1,10 @@
+{
+  "hide-profile-counters": "",
+  "hide-follow-recommendations": "",
+  "hide-news": "",
+  "hide-premium": {
+    "top": "",
+    "sidebar": ""
+  },
+  "hide-games": ""
+}


### PR DESCRIPTION
Add a JSON locale file per LinkedIn-supported language to store section titles for content-based targeting, keyed by hideable section.

This is only a base made to start allowing users to contribute to the text-based migration of the misc features

Only filled en_US as a demonstration file 

Didn't fill "hide-news" because Linkedin just don't want to give me this section, Idk why
